### PR TITLE
docker: change from port mapping to exposing ports on containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ui:
     container_name: ui
     build: ./web_frontend
-    expose:
+    expose: # CURRENTLY CONFIGURED FOR PRODUCTION NGINX ENVIRONMENT -> CHANGE TO `port: - 3000:3000` for localhost without docker copntainerization
       - 3000
     depends_on:
       - backend
@@ -10,7 +10,7 @@ services:
   backend:
     container_name: backend
     build: ./backend
-    expose:
+    expose: # CURRENTLY CONFIGURED FOR PRODUCTION NGINX ENVIRONMENT -> CHANGE TO `port: - 3001:3001` for localhost without docker copntainerization
       - 3001
     depends_on:
       - mongo
@@ -20,8 +20,8 @@ services:
     image: mongo
     volumes:
       - mongo-volume:/data/db
-    ports:
-      - 27017:27017
+    expose:
+      - 27017
   
 volumes:
   mongo-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,16 @@ services:
   ui:
     container_name: ui
     build: ./web_frontend
-    ports:
-      - 3000:3000
+    expose:
+      - 3000
     depends_on:
       - backend
 
   backend:
     container_name: backend
     build: ./backend
-    ports:
-      - 3001:3001
+    expose:
+      - 3001
     depends_on:
       - mongo
 


### PR DESCRIPTION
now that I have a working containerized nginx setup via https://github.com/tmanti/hosting-services, I can begin to remove some of the clutter on my VPS. 

WRT. these changes it removes the need to fight for ports on my VPS as I begin to develop more tools to be hosted.